### PR TITLE
Creación EPs de consulta de información

### DIFF
--- a/src/main/java/com/wombats/mspipelinemetrobus/controller/AlcaldiaController.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/controller/AlcaldiaController.java
@@ -1,5 +1,6 @@
 package com.wombats.mspipelinemetrobus.controller;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,24 @@ public class AlcaldiaController {
 	public Optional<Alcaldia> obtenerAlcaldiaPorCoordenadas(@RequestParam("latitud") String latitud,
 			@RequestParam("longitud") String longitud) {
 		return alcaldiaService.obtenerAlcaldiaPorCoordenadas(latitud, longitud);
+	}
+	
+	/**
+	 * End Point para la obtener catálogo de alcaldías
+	 * @return Lista de alcaldías
+	 */
+	@GetMapping("/catalogo")
+	public List<Alcaldia> obtenerAlcaldias() {
+		return alcaldiaService.obtenerAlcaldias();
+	}
+	
+	/**
+	 * End Point para la obtener alcaldías disponibles en ubicaciones de metrobus
+	 * @return Lista de alcaldías
+	 */
+	@GetMapping("/disponibles")
+	public List<Alcaldia> obtenerAlcaldiasDisponibles() {
+		return alcaldiaService.obtenerAlcaldiasDisponibles();
 	}
 
 }

--- a/src/main/java/com/wombats/mspipelinemetrobus/controller/UbicacionMetrobusController.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/controller/UbicacionMetrobusController.java
@@ -1,10 +1,15 @@
 package com.wombats.mspipelinemetrobus.controller;
 
+import java.util.List;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.wombats.mspipelinemetrobus.dto.UbicacionMetrobus;
 import com.wombats.mspipelinemetrobus.service.IUbicacionMetrobusService;
 
 /**
@@ -28,6 +33,30 @@ public class UbicacionMetrobusController {
 	@PostMapping("/carga/masiva")
 	public void cargarUbicacionesMetrobus() {
 		ubicacionMetrobusService.cargarUbicacionesMetrobus();
+	}
+	
+	/**
+	 * End Point que realiza la búsqueda de ubicaciones de metrobus por estatus
+	 */
+	@GetMapping("/{unidadEstatus}/estatus")
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobusPorEstatus(@PathVariable("unidadEstatus") Integer unidadEstatus) {
+		return ubicacionMetrobusService.obtenerUbicacionesMetrobusPorEstatus(unidadEstatus);
+	}
+	
+	/**
+	 * End Point que realiza la búsqueda de ubicaciones de metrobus por unidad ID
+	 */
+	@GetMapping("/{unidadId}/unidad")
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobusPorUnidadId(@PathVariable("unidadId") Long unidadId) {
+		return ubicacionMetrobusService.obtenerUbicacionesMetrobusPorUnidadId(unidadId);
+	}
+	
+	/**
+	 * End Point que realiza la búsqueda de ubicaciones de metrobus por alcaldía ID
+	 */
+	@GetMapping("/{alcaldiaId}/alcaldia")
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobusPorAlcaldiaId(@PathVariable("alcaldiaId") Long alcaldiaId) {
+		return ubicacionMetrobusService.obtenerUbicacionesMetrobusPorAlcaldiaId(alcaldiaId);
 	}
 
 }

--- a/src/main/java/com/wombats/mspipelinemetrobus/dto/UbicacionMetrobus.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/dto/UbicacionMetrobus.java
@@ -1,0 +1,30 @@
+package com.wombats.mspipelinemetrobus.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author Edgar Quiroz
+ * @version 16/10/20 1.0.0
+ * DTO de ubicaciones de metrobus
+ */
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UbicacionMetrobus {
+
+	private Long id;
+	private Long unidadId;
+	private String unidadEtiqueta;
+	private Integer unidadEstatus;
+	private String ubicacionLatitud;
+	private String ubicacionLongitud;
+	private LocalDateTime fechaActualizacion;
+	private Alcaldia alcaldia;
+	
+}

--- a/src/main/java/com/wombats/mspipelinemetrobus/mapper/UbicacionMetrobusMapper.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/mapper/UbicacionMetrobusMapper.java
@@ -2,9 +2,14 @@ package com.wombats.mspipelinemetrobus.mapper;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
+import org.springframework.beans.BeanUtils;
+
+import com.wombats.mspipelinemetrobus.dto.UbicacionMetrobus;
 import com.wombats.mspipelinemetrobus.dto.UbicacionMetrobusApi.Fields;
 import com.wombats.mspipelinemetrobus.entity.UbicacionMetrobusEntity;
+import com.wombats.mspipelinemetrobus.projection.AlcaldiaEntityProjection;
 
 /**
  * @author Edgar Quiroz
@@ -35,6 +40,23 @@ public final class UbicacionMetrobusMapper {
 				.ubicacionLongitud(String.valueOf(ubicacionMetrobus.getPositionLongitude()))
 				.fechaActualizacion(fechaActualizacion)
 				.build();
+	}
+	
+	/**
+	 * Método para generar un DTO de ubicaciones de metrobus
+	 * @param Entidad de ubicaciones de metrobus
+	 * @param Proyección SQL de la alcaldía asociada a los datos de la ubicación del metrobus
+	 * @return DTO de ubicaciones de metrobus
+	 */
+	public static UbicacionMetrobus toDto(UbicacionMetrobusEntity ubicacionMetrobusEntity, Optional<AlcaldiaEntityProjection> alcaldiaEntityProjection) {
+		UbicacionMetrobus ubicacionMetrobus = UbicacionMetrobus.builder().build();
+		BeanUtils.copyProperties(ubicacionMetrobusEntity, ubicacionMetrobus);
+		
+		if (alcaldiaEntityProjection.isPresent()) {
+			ubicacionMetrobus.setAlcaldia(AlcaldiaMapper.toDto(alcaldiaEntityProjection.get()));
+		}
+		
+		return ubicacionMetrobus;
 	}
 
 }

--- a/src/main/java/com/wombats/mspipelinemetrobus/repository/AlcaldiaEntityRepository.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/repository/AlcaldiaEntityRepository.java
@@ -1,6 +1,8 @@
 package com.wombats.mspipelinemetrobus.repository;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,7 +20,6 @@ import com.wombats.mspipelinemetrobus.projection.AlcaldiaEntityProjection;
 @Repository
 public interface AlcaldiaEntityRepository extends JpaRepository<AlcaldiaEntity, Long> {
 	
-	@Override
 	@Modifying
 	@Query(value = "DELETE FROM alcaldia WHERE 1 = 1", nativeQuery = true)
 	void deleteAll();
@@ -30,6 +31,15 @@ public interface AlcaldiaEntityRepository extends JpaRepository<AlcaldiaEntity, 
 	@Query(value = "SELECT a.id, a.nombre " + 
 			"FROM alcaldia a " + 
 			"WHERE ST_CONTAINS(a.region, POINT(?1, ?2)) ", nativeQuery = true)
-	Optional<AlcaldiaEntityProjection> findByCoordenadas(String latitud, String longitud);
+	Optional<AlcaldiaEntityProjection> findProjectionByCoordenadas(String latitud, String longitud);
+	
+	@Query(value = "SELECT a.id, a.nombre " + 
+			"FROM alcaldia a " + 
+			"WHERE a.id IN ?1 ", nativeQuery = true)
+	List<AlcaldiaEntityProjection> findAllProjectionByIdIn(Set<Long> id);
+	
+	@Query(value = "SELECT a.id, a.nombre " + 
+			"FROM alcaldia a ", nativeQuery = true)
+	List<AlcaldiaEntityProjection> findAllProjection();
 	
 }

--- a/src/main/java/com/wombats/mspipelinemetrobus/repository/UbicacionMetrobusEntityRepository.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/repository/UbicacionMetrobusEntityRepository.java
@@ -1,5 +1,7 @@
 package com.wombats.mspipelinemetrobus.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +14,11 @@ import com.wombats.mspipelinemetrobus.entity.UbicacionMetrobusEntity;
  */
 @Repository
 public interface UbicacionMetrobusEntityRepository extends JpaRepository<UbicacionMetrobusEntity, Long> {
+	
+	List<UbicacionMetrobusEntity> findAllByUnidadEstatus(Integer unidadEstatus);
+	
+	List<UbicacionMetrobusEntity> findAllByUnidadId(Long unidadId);
+	
+	List<UbicacionMetrobusEntity> findAllByAlcaldiaId(Long alcaldiaId);
+	
 }

--- a/src/main/java/com/wombats/mspipelinemetrobus/service/IAlcaldiaService.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/service/IAlcaldiaService.java
@@ -1,10 +1,14 @@
 package com.wombats.mspipelinemetrobus.service;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import org.springframework.stereotype.Service;
 
 import com.wombats.mspipelinemetrobus.dto.Alcaldia;
+import com.wombats.mspipelinemetrobus.projection.AlcaldiaEntityProjection;
 
 /**
  * @author Edgar Quiroz
@@ -18,6 +22,10 @@ public interface IAlcaldiaService {
 	
 	public Optional<Alcaldia> obtenerAlcaldiaPorCoordenadas(String latitud, String longitud);
 	
-	public Long contarAlcaldias();
+	public Map<Long, AlcaldiaEntityProjection> obtenerAlcaldiasMap(Set<Long> alcaldiaIds);
+	
+	public List<Alcaldia> obtenerAlcaldias();
+	
+	public List<Alcaldia> obtenerAlcaldiasDisponibles();
 
 }

--- a/src/main/java/com/wombats/mspipelinemetrobus/service/IUbicacionMetrobusService.java
+++ b/src/main/java/com/wombats/mspipelinemetrobus/service/IUbicacionMetrobusService.java
@@ -1,6 +1,12 @@
 package com.wombats.mspipelinemetrobus.service;
 
+import java.util.List;
+import java.util.Set;
+
 import org.springframework.stereotype.Service;
+
+import com.wombats.mspipelinemetrobus.dto.UbicacionMetrobus;
+import com.wombats.mspipelinemetrobus.entity.UbicacionMetrobusEntity;
 
 /**
  * @author Edgar Quiroz
@@ -11,5 +17,15 @@ import org.springframework.stereotype.Service;
 public interface IUbicacionMetrobusService {
 	
 	public void cargarUbicacionesMetrobus();
+	
+	public Set<Long> obtenerAlcaldiaIds(List<UbicacionMetrobusEntity> ubicacionMetrobusEntityList);
+	
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobus(List<UbicacionMetrobusEntity> ubicacionMetrobusEntityList);
+	
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobusPorEstatus(Integer unidadEstatus);
+	
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobusPorUnidadId(Long unidadId);
+	
+	public List<UbicacionMetrobus> obtenerUbicacionesMetrobusPorAlcaldiaId(Long alcaldiaId);
 	
 }


### PR DESCRIPTION
- Creación EPs para consultar ubicaciones de metrobus por estatus, unidad ID y alcaldía ID.
- Creación EPs para consultar alcaldías disponibles y por catálogo.
- Creación EPs para consultar alcaldías disponibles y por catálogo.
- Creación DTO de ubicaciones de metrobus.
- Agregación consultas JPA y native SQL en repositorios.